### PR TITLE
Get server port from -port flag

### DIFF
--- a/src/snake/main/main.go
+++ b/src/snake/main/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -15,10 +17,13 @@ func mainHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func main() {
+	portPtr := flag.Int("port", 80, "server port")
+	flag.Parse()
+
 	http.HandleFunc("/", mainHandler)
 	http.Handle("/static/", http.FileServer(http.Dir(".")))
 	http.Handle("/ws", connection.ConnectionHandler)
-	err := http.ListenAndServe(":80", nil)
+	err := http.ListenAndServe(fmt.Sprintf(":%d", *portPtr), nil)
 	if err != nil {
 		panic("ListenAndServe: " + err.Error())
 	}


### PR DESCRIPTION
This allows users to set the port to a non-privileged port, allowing them to run it without `sudo` or root.

Now, the server can be run with `./snake -port=$PORT`.
